### PR TITLE
Update weather entity to 2023.9 format

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -6,3 +6,6 @@ logger:
   default: info
   logs:
     custom_components.integration_blueprint: debug
+
+weather:
+  - platform: demo

--- a/custom_components/weatherkit/api.py
+++ b/custom_components/weatherkit/api.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections import OrderedDict
 import socket
+from urllib.parse import urlencode
 
 import aiohttp
 import async_timeout
@@ -32,7 +34,6 @@ class WeatherKitApiClient:
         key_pem: str,
         session: aiohttp.ClientSession,
     ) -> None:
-        """Sample API Client."""
         self._key_id = key_id
         self._service_id = service_id
         self._team_id = team_id
@@ -44,9 +45,19 @@ class WeatherKitApiClient:
     ) -> any:
         """OBTAIN WEATHER DATA!!!!!!!!!!"""
         token = self._generate_jwt()
+        query = urlencode(
+            OrderedDict(
+                dataSets="currentWeather,forecastDaily,forecastHourly",
+                hourlyStart=datetime.datetime.utcnow().isoformat() + "Z",
+                hourlyEnd=(
+                    datetime.datetime.utcnow() + datetime.timedelta(days=1)
+                ).isoformat()
+                + "Z",
+            )
+        )
         return await self._api_wrapper(
             method="get",
-            url=f"https://weatherkit.apple.com/api/v1/weather/{lang}/{lat}/{lon}?dataSets=currentWeather,forecastDaily",
+            url=f"https://weatherkit.apple.com/api/v1/weather/{lang}/{lat}/{lon}?{query}",
             headers={"Authorization": f"Bearer {token}"},
         )
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Apple WeatherKit",
-    "homeassistant": "2023.7.0",
+    "homeassistant": "2023.9.0",
     "render_readme": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.7.0
-homeassistant==2023.8.0
+homeassistant==2023.9.0b0
 pip>=21.0,<23.2
 ruff==0.0.267
 pyjwt[crypto]==2.*


### PR DESCRIPTION
Home Assistant 2023.9 introduces some changes to the weather entity which makes it possible for them to provide both an hourly and daily forecast. This update satisfies these changes. The PR will be merged when 2023.9 is released